### PR TITLE
Add interface addition event in SchemaDiff

### DIFF
--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -537,7 +537,7 @@ public class SchemaDiff {
         for (Map.Entry<String, Type> entry : newImplementsMap.entrySet()) {
             Optional<InterfaceTypeDefinition> newInterface = ctx.getNewTypeDef(entry.getValue(), InterfaceTypeDefinition.class);
             if (!oldImplementsMap.containsKey(entry.getKey())) {
-                ctx.report(DiffEvent.apiDanger()
+                ctx.report(DiffEvent.apiInfo()
                         .category(DiffCategory.ADDITION)
                         .typeName(old.getName())
                         .typeKind(getTypeKind(old))

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -533,6 +533,19 @@ public class SchemaDiff {
                 checkInterfaceType(ctx, oldInterface.get(), newInterface.get());
             }
         }
+
+        for (Map.Entry<String, Type> entry : newImplementsMap.entrySet()) {
+            Optional<InterfaceTypeDefinition> newInterface = ctx.getNewTypeDef(entry.getValue(), InterfaceTypeDefinition.class);
+            if (!oldImplementsMap.containsKey(entry.getKey())) {
+                ctx.report(DiffEvent.apiDanger()
+                        .category(DiffCategory.ADDITION)
+                        .typeName(old.getName())
+                        .typeKind(getTypeKind(old))
+                        .components(newInterface.get().getName())
+                        .reasonMsg("The new API has added the interface named '%s'", newInterface.get().getName())
+                        .build());
+            }
+        }
     }
 
 

--- a/src/main/java/graphql/schema/diff/SchemaDiff.java
+++ b/src/main/java/graphql/schema/diff/SchemaDiff.java
@@ -135,8 +135,8 @@ public class SchemaDiff {
      * This will perform a difference on the two schemas.  The reporter callback
      * interface will be called when differences are encountered.
      *
-     * @param schemaDiffSet  the two schemas to compare for difference
-     * @param reporter the place to report difference events to
+     * @param schemaDiffSet the two schemas to compare for difference
+     * @param reporter      the place to report difference events to
      *
      * @return the number of API breaking changes
      */

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -778,7 +778,7 @@ class SchemaDiffTest extends Specification {
             a: String
         }
         interface Bar {
-            b: String
+            a: String
         }
        ''')
         def newSchema = TestUtil.schema('''
@@ -786,11 +786,10 @@ class SchemaDiffTest extends Specification {
             foo: Foo
         }
         type Foo implements Bar {
-            a: String
-            b: String
+            a: String            
         }
         interface Bar {
-            b: String
+            a: String
         }
        ''')
 
@@ -799,10 +798,13 @@ class SchemaDiffTest extends Specification {
 
         then:
         validateReportersAreEqual()
-        introspectionReporter.dangerCount == 1
         introspectionReporter.breakageCount == 0
-        introspectionReporter.dangers.every {
-            it.getCategory() == DiffCategory.ADDITION
+        introspectionReporter.infos.any {
+            it.category == DiffCategory.ADDITION &&
+                    it.typeKind == TypeKind.Object &&
+                    it.typeName == "Foo" &&
+                    it.level == DiffLevel.INFO
         }
+
     }
 }

--- a/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
+++ b/src/test/groovy/graphql/schema/diff/SchemaDiffTest.groovy
@@ -768,4 +768,41 @@ class SchemaDiffTest extends Specification {
         then:
         thrown(AssertException)
     }
+
+    def "checkImplements emits ADDITION events for new interfaces"() {
+        def oldSchema = TestUtil.schema('''
+        type Query {
+            foo: Foo
+        }
+        type Foo {
+            a: String
+        }
+        interface Bar {
+            b: String
+        }
+       ''')
+        def newSchema = TestUtil.schema('''
+        type Query {
+            foo: Foo
+        }
+        type Foo implements Bar {
+            a: String
+            b: String
+        }
+        interface Bar {
+            b: String
+        }
+       ''')
+
+        when:
+        compareDiff(oldSchema, newSchema)
+
+        then:
+        validateReportersAreEqual()
+        introspectionReporter.dangerCount == 1
+        introspectionReporter.breakageCount == 0
+        introspectionReporter.dangers.every {
+            it.getCategory() == DiffCategory.ADDITION
+        }
+    }
 }


### PR DESCRIPTION
Update `SchemaDiff.checkImplements` to emit ADDITION events for new interfaces.

* Add a loop to iterate over new interfaces and check if they are present in old interfaces.
* Emit an ADDITION event if a new interface is not present in the old interfaces.
* Retain the existing behavior with respect to interface removals.

Add a new test case in `SchemaDiffTest.groovy` to verify that `checkImplements` emits ADDITION events for new interfaces.
